### PR TITLE
ADD: Se agrega Carta Porte 3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 apply from: 'download.gradle'
 
 group 'mx.grupocorasa.cfdibase'
-version '4.0.17'
+version '4.0.18'
 
 publishing {
     repositories {
@@ -20,7 +20,7 @@ publishing {
                 username = env.USERNAME.value
                 password = env.GP_TOKEN.value
             }
-        }
+            }
     }
     publications {
         gpr(MavenPublication) {
@@ -316,6 +316,11 @@ xjcGeneration {
 			bindingFile = 'src/main/resources/bindingFiles/CartaPorte30_bind.xml'
 			schemaRootDir = 'src/main/resources'
 			schemaFile = 'xsd/common/CartaPorte/CartaPorte30.xsd'
+		}
+		mx_grupocorasa_sat_common_CartaPorte31{
+			bindingFile = 'src/main/resources/bindingFiles/CartaPorte31_bind.xml'
+			schemaRootDir = 'src/main/resources'
+			schemaFile = 'xsd/common/CartaPorte/CartaPorte31.xsd'
 		}
 		mx_grupocorasa_sat_cfd_40{
 			bindingFile = 'src/main/resources/bindingFiles/cfdv40_bind.xml'

--- a/src/main/java/mx/grupocorasa/sat/cfdi/v4/CFDv40.java
+++ b/src/main/java/mx/grupocorasa/sat/cfdi/v4/CFDv40.java
@@ -33,6 +33,7 @@ public final class CFDv40 extends CFDv4 {
             "/xsd/cfd/4/cfdv40.xsd",
             "/xsd/common/CartaPorte/CartaPorte20.xsd",
             "/xsd/common/CartaPorte/CartaPorte30.xsd",
+            "/xsd/common/CartaPorte/CartaPorte31.xsd",
             "/xsd/common/ComercioExterior11/ComercioExterior11.xsd",
             "/xsd/common/ComercioExterior20/ComercioExterior20.xsd",
             "/xsd/common/EstadoDeCuentaCombustible/ecc12.xsd",

--- a/src/main/java/mx/grupocorasa/sat/common/CfdCommon.java
+++ b/src/main/java/mx/grupocorasa/sat/common/CfdCommon.java
@@ -245,6 +245,7 @@ public abstract class CfdCommon implements CfdInterface {
 		namespaceMap.put("catPagos:mx.grupocorasa.sat.common.catalogos.Pagos", "http://www.sat.gob.mx/sitio_internet/cfd/catalogos/Pagos");
 		namespaceMap.put("aerolineas:mx.grupocorasa.sat.common.aerolineas10", "http://www.sat.gob.mx/aerolineas");
 		namespaceMap.put("cartaporte30:mx.grupocorasa.sat.common.CartaPorte30", "http://www.sat.gob.mx/CartaPorte30");
+		namespaceMap.put("cartaporte31:mx.grupocorasa.sat.common.CartaPorte31", "http://www.sat.gob.mx/CartaPorte31");
 		namespaceMap.put("iedu:mx.grupocorasa.sat.common.iedu10", "http://www.sat.gob.mx/iedu");
 		namespaceMap.put("pago20:mx.grupocorasa.sat.common.Pagos20", "http://www.sat.gob.mx/Pagos20");
 		namespaceMap.put("notariospublicos:mx.grupocorasa.sat.common.notariospublicos10", "http://www.sat.gob.mx/notariospublicos");

--- a/src/main/resources/bindingFiles/CartaPorte31_bind.xml
+++ b/src/main/resources/bindingFiles/CartaPorte31_bind.xml
@@ -1,0 +1,39 @@
+<jaxb:bindings version="3.0"
+    xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+    xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <jaxb:bindings>
+        <jaxb:globalBindings typesafeEnumMaxMembers="100000" typesafeEnumMemberName="generateName">
+            <xjc:javaType name="java.time.LocalDateTime" xmlType="xs:dateTime" adapter="mx.grupocorasa.sat.util.DateTimeAdapter"/>
+            <xjc:javaType name="java.time.LocalDate" xmlType="xs:date" adapter="mx.grupocorasa.sat.util.DateAdapter"/>
+        </jaxb:globalBindings>
+    </jaxb:bindings>
+	<jaxb:bindings>
+        <jaxb:bindings schemaLocation="../xsd/common/catalogos/catCFDI.xsd" node="/xs:schema">
+            <jaxb:schemaBindings>
+                <jaxb:package name="mx.grupocorasa.sat.common.catalogos"/>
+            </jaxb:schemaBindings>
+        </jaxb:bindings>
+    </jaxb:bindings>
+	<jaxb:bindings>
+        <jaxb:bindings schemaLocation="../xsd/common/catalogos/ComExt/catComExt.xsd" node="/xs:schema">
+            <jaxb:schemaBindings>
+                <jaxb:package name="mx.grupocorasa.sat.common.catalogos.ComExt"/>
+            </jaxb:schemaBindings>
+        </jaxb:bindings>
+    </jaxb:bindings>
+	<jaxb:bindings>
+        <jaxb:bindings schemaLocation="../xsd/common/catalogos/CartaPorte/catCartaPorte.xsd" node="/xs:schema">
+            <jaxb:schemaBindings>
+                <jaxb:package name="mx.grupocorasa.sat.common.catalogos.CartaPorte"/>
+            </jaxb:schemaBindings>
+        </jaxb:bindings>
+    </jaxb:bindings>
+	<jaxb:bindings>
+        <jaxb:bindings schemaLocation="../xsd/common/CartaPorte/CartaPorte31.xsd" node="/xs:schema">
+            <jaxb:schemaBindings>
+                <jaxb:package name="mx.grupocorasa.sat.common.CartaPorte31"/>
+            </jaxb:schemaBindings>
+        </jaxb:bindings>
+    </jaxb:bindings>
+</jaxb:bindings>


### PR DESCRIPTION
Hola buenas tardes

Podrían ayudarme con este PR para agregar 

Carta porte 3.1

- El complemento Carta Porte versión 3.1, se publicó en el Portal del SAT el 17 de junio de 2024.

- El complemento Carta Porte versión 3.1, se debe estar utilizando a partir del 17 de julio de 2024.

- En operaciones de comercio exterior, la factura con complemento Carta Porte es exigible desde el 01 de enero de 2024.